### PR TITLE
Fix accuracy in Gen I and Gen II

### DIFF
--- a/mods/gen2/items.js
+++ b/mods/gen2/items.js
@@ -1,6 +1,15 @@
 'use strict';
 
 exports.BattleItems = {
+	brightpowder: {
+		inherit: true,
+		onModifyAccuracy: function (accuracy) {
+			if (typeof accuracy !== 'number') return;
+			this.debug('brightpowder - decreasing accuracy');
+			return accuracy - 20;
+		},
+		desc: "The accuracy of attacks against the holder is reduced slightly.",
+	},
 	berryjuice: {
 		inherit: true,
 		isUnreleased: false,


### PR DESCRIPTION
Bug reported in #3226, added to #2367 (Known Mechanics Bugs). Capping accuracy to 255 in Gen I and II